### PR TITLE
Add pageToCanvas function to convert coordinates from page to canvas context

### DIFF
--- a/src/pageToCanvas.js
+++ b/src/pageToCanvas.js
@@ -1,0 +1,24 @@
+(function(cornerstone) {
+
+    "use strict";
+
+    /**
+     * Converts a point in the page coordinate system to the canvas coordinate system.
+     * This can be used in tools to compare handle/tool and mouse pointer distance
+     * regardless of image resolution/zoom.
+     * @param element
+     * @param pt
+     * @returns {x: number, y: number}
+     */
+    function pageToCanvas(element, pt) {
+        var rect = element.getBoundingClientRect();
+        return {
+            x: pt.x - rect.left - window.pageXOffset,
+            y: pt.y - rect.top - window.pageYOffset,
+        };
+    }
+
+    // module/private exports
+    cornerstone.pageToCanvas = pageToCanvas;
+
+}(cornerstone));


### PR DESCRIPTION
Get canvas context coordinates in screen pixels. Can be used by tools to compare screen pixel distance between mouse and handles/tools.