### PR TITLE
Display the images that have only VOI LUT Sequence properly

### DIFF
--- a/src/internal/generateLut.js
+++ b/src/internal/generateLut.js
@@ -16,7 +16,7 @@
     var minPixelValue = image.minPixelValue;
 
     var mlutfn = cornerstone.internal.getModalityLUT(image.slope, image.intercept, modalityLUT);
-    var vlutfn = cornerstone.internal.getVOILUT(windowWidth, windowCenter, voiLUT);
+    var vlutfn = cornerstone.internal.getVOILUT(windowWidth, windowCenter, image.bitsStored, minPixelValue, maxPixelValue, voiLUT);
 
     var offset = 0;
     if(minPixelValue < 0) {

--- a/src/internal/voiLUT.js
+++ b/src/internal/voiLUT.js
@@ -12,29 +12,42 @@
     }
   }
 
-  function generateNonLinearVOILUT(voiLUT) {
-    var shift = voiLUT.numBitsPerEntry - 8;
+  function generateNonLinearVOILUT(windowWidth, windowCenter, bitsStored, minPixelValue, maxPixelValue, voiLUT) {
+    // Shift the stored value based on bitsStored, not always 8 bits
+    var shift = voiLUT.numBitsPerEntry - (bitsStored || 8);
     var minValue = voiLUT.lut[0] >> shift;
     var maxValue = voiLUT.lut[voiLUT.lut.length -1] >> shift;
     var maxValueMapped = voiLUT.firstValueMapped + voiLUT.lut.length - 1;
     return function(modalityLutValue) {
+      var voiLutValue;
       if(modalityLutValue < voiLUT.firstValueMapped) {
-        return minValue;
+        voiLutValue = minValue;
       }
-      else if(modalityLutValue >= maxValueMapped)
-      {
-        return maxValue;
+      else if(modalityLutValue >= maxValueMapped) {
+        voiLutValue = maxValue;
       }
-      else
-      {
-        return voiLUT.lut[modalityLutValue - voiLUT.firstValueMapped] >> shift;
+      else {
+        voiLutValue = voiLUT.lut[modalityLutValue - voiLUT.firstValueMapped] >> shift;
+      }
+
+      // Apply the linear conversion from stored pixel values (after any Modality LUT or Rescale Slope and
+      // Intercept specified in the IOD have been applied) to the values to be displayed based on Window Width
+      // and Window Center
+      if (voiLutValue <= windowCenter - 0.5 - (windowWidth-1) / 2) {
+        return 0;
+      }
+      else if (voiLutValue > windowCenter - 0.5 + (windowWidth-1) / 2) {
+        return 255;
+      }
+      else {
+        return ((voiLutValue - (windowCenter-0.5)) / (windowWidth-1) + 0.5) * (maxPixelValue-minPixelValue) + minPixelValue;
       }
     }
   }
 
-  function getVOILUT(windowWidth, windowCenter, voiLUT) {
+  function getVOILUT(windowWidth, windowCenter, bitsStored, minPixelValue, maxPixelValue, voiLUT) {
     if(voiLUT) {
-      return generateNonLinearVOILUT(voiLUT);
+      return generateNonLinearVOILUT(windowWidth, windowCenter, bitsStored, minPixelValue, maxPixelValue, voiLUT);
     } else {
       return generateLinearVOILUT(windowWidth, windowCenter);
     }


### PR DESCRIPTION
The images that have only VOI LUT Sequence and bitsStored other than 8 are not displayed properly, and changes in Window/Level are not applied to the image.

The following changes were applied to fix this issue:
- Shift the stored VOI LUT values by "numBitsPerEntryInVOILutData - bitsStored" instead of "numBitsPerEntryInVOILutData - 8"
- Implement the default linear function for the images that have only VOI LUT Sequence to apply Window Width and Window Center changed by user

Tested with the image that have the following attributes and does not have Window Width and Window Center.
```
(0028,0100) US 16                                       #   2, 1 BitsAllocated
(0028,0101) US 12                                       #   2, 1 BitsStored
(0028,0102) US 11                                       #   2, 1 HighBit
(0028,0103) US 0                                        #   2, 1 PixelRepresentation
(0028,1052) DS [0]                                      #   2, 1 RescaleIntercept
(0028,1053) DS [1]                                      #   2, 1 RescaleSlope
(0028,1054) LO [LOG_E REL]                              #  10, 1 RescaleType
(0028,3010) SQ (Sequence with undefined length #=1)     # u/l, 1 VOILUTSequence
  (fffe,e000) na (Item with undefined length #=3)         # u/l, 1 Item
    (0028,3002) SS 2065\736\16                              #   6, 3 LUTDescriptor
    (0028,3003) LO [NK5]                                    #   4, 1 LUTExplanation
    (0028,3006) OW 0000\0000\0001\0001\0001\0002\0002\0003\0003\0003\0004\0004\0004... # 4130, 1 LUTData
  (fffe,e00d) na (ItemDelimitationItem)                   #   0, 0 ItemDelimitationItem
(fffe,e0dd) na (SequenceDelimitationItem)               #   0, 0 SequenceDelimitationItem
```