### PR TITLE
Trigger CornerstoneImageRendered after resetting render flags.

### DIFF
--- a/src/enable.js
+++ b/src/enable.js
@@ -48,9 +48,9 @@
                     renderTimeInMs: diff
                 };
 
-                $(el.element).trigger("CornerstoneImageRendered", eventData);
                 el.invalid = false;
                 el.needsRedraw = false;
+                $(el.element).trigger("CornerstoneImageRendered", eventData);
             }
 
             cornerstone.requestAnimationFrame(draw);


### PR DESCRIPTION
It makes more sense to trigger CornerstoneImageRendered after
the invalid and needsRedraw flags have been reset in case any
event handler needs to trigger another rendering pass.