### PR TITLE
Add CornerstoneElementResized event.

### DIFF
--- a/src/resize.js
+++ b/src/resize.js
@@ -45,6 +45,12 @@
 
         setCanvasSize(element, enabledElement.canvas);
 
+        var eventData = {
+            element: element
+        };
+
+        $(element).trigger("CornerstoneElementResized", eventData);
+
         if(enabledElement.image === undefined ) {
             return;
         }


### PR DESCRIPTION
Add an event trigger after the canvas is resized, but before
the image render is triggered.