### PR TITLE
Add a 'CornerstoneRAF' event that is fire before the image is rendered.

### DIFF
--- a/src/enable.js
+++ b/src/enable.js
@@ -61,10 +61,13 @@ export default function (element, options) {
    *
    * @returns {void}
    */
-  function draw () {
+  function draw (timestamp) {
     if (el.canvas === undefined) {
       return;
     }
+
+    $(el.element).trigger('CornerstonePreRender', { enabledElement: el, timestamp: timestamp });
+
     if (el.needsRedraw && el.image !== undefined) {
       const start = new Date();
       let render = el.image.render;


### PR DESCRIPTION
This allows, for instance, the CINE tools the change the image just
as it is about to be rendered.

Maybe the name could be reconsidered? Naming is hard.. 