### PR TITLE
Fix import/export extentions

### DIFF
--- a/src/colors/colormap.js
+++ b/src/colors/colormap.js
@@ -1,4 +1,4 @@
-import LookupTable from './lookupTable';
+import LookupTable from './lookupTable.js';
 
 const COLOR_BLACK = [0, 0, 0, 255];
 

--- a/src/colors/index.js
+++ b/src/colors/index.js
@@ -1,5 +1,5 @@
-import { getColormap, getColormapsList } from './colormap';
-import LookupTable from './lookupTable';
+import { getColormap, getColormapsList } from './colormap.js';
+import LookupTable from './lookupTable.js';
 
 export default {
   getColormap,

--- a/src/enable.js
+++ b/src/enable.js
@@ -5,8 +5,8 @@
 import { addEnabledElement } from './enabledElements.js';
 import resize from './resize.js';
 import requestAnimationFrame from './internal/requestAnimationFrame.js';
-import { renderColorImage } from './rendering/renderColorImage';
-import { renderGrayscaleImage } from './rendering/renderGrayscaleImage';
+import { renderColorImage } from './rendering/renderColorImage.js';
+import { renderGrayscaleImage } from './rendering/renderGrayscaleImage.js';
 import webGL from './webgl/index.js';
 
 /**

--- a/src/falseColorMapping.js
+++ b/src/falseColorMapping.js
@@ -1,7 +1,7 @@
-import { getEnabledElement } from './enabledElements';
-import updateImage from './updateImage';
-import pixelDataToFalseColorData from './pixelDataToFalseColorData';
-import { getColormap } from './colors/colormap';
+import { getEnabledElement } from './enabledElements.js';
+import updateImage from './updateImage.js';
+import pixelDataToFalseColorData from './pixelDataToFalseColorData.js';
+import { getColormap } from './colors/colormap.js';
 
 /**
  * Retrieves the minimum and maximum pixel values from an Array of pixel data

--- a/src/imageCache.js
+++ b/src/imageCache.js
@@ -10,7 +10,7 @@ const imageCacheDict = {};
 // Array of cachedImage objects
 export const cachedImages = [];
 
-import events from './events';
+import events from './events.js';
 
 export function setMaximumSizeBytes (numBytes) {
   if (numBytes === undefined) {

--- a/src/imageLoader.js
+++ b/src/imageLoader.js
@@ -2,7 +2,7 @@
  * This module deals with ImageLoaders, loading images and caching images
  */
 import { getImagePromise, putImagePromise } from './imageCache.js';
-import events from './events';
+import events from './events.js';
 
 const imageLoaders = {};
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,64 +1,64 @@
 // Internal (some of these are from old internal/legacy expose)
-export { default as drawImage } from './internal/drawImage';
-export { default as generateLut } from './internal/generateLut';
-export { default as generateLutNew } from './internal/generateLutNew';
-export { default as getDefaultViewport } from './internal/getDefaultViewport';
-export { default as requestAnimationFrame } from './internal/requestAnimationFrame';
-export { default as storedPixelDataToCanvasImageData } from './internal/storedPixelDataToCanvasImageData';
-export { default as storedColorPixelDataToCanvasImageData } from './internal/storedColorPixelDataToCanvasImageData';
+export { default as drawImage } from './internal/drawImage.js';
+export { default as generateLut } from './internal/generateLut.js';
+export { default as generateLutNew } from './internal/generateLutNew.js';
+export { default as getDefaultViewport } from './internal/getDefaultViewport.js';
+export { default as requestAnimationFrame } from './internal/requestAnimationFrame.js';
+export { default as storedPixelDataToCanvasImageData } from './internal/storedPixelDataToCanvasImageData.js';
+export { default as storedColorPixelDataToCanvasImageData } from './internal/storedColorPixelDataToCanvasImageData.js';
 
-export { default as internal } from './internal/index';
+export { default as internal } from './internal/index.js';
 
 // Rendering
-export { renderColorImage } from './rendering/renderColorImage';
-export { renderGrayscaleImage } from './rendering/renderGrayscaleImage';
-export { renderWebImage } from './rendering/renderWebImage';
+export { renderColorImage } from './rendering/renderColorImage.js';
+export { renderGrayscaleImage } from './rendering/renderGrayscaleImage.js';
+export { renderWebImage } from './rendering/renderWebImage.js';
 
-export { default as canvasToPixel } from './canvasToPixel';
-export { default as disable } from './disable';
-export { default as displayImage } from './displayImage';
-export { default as draw } from './draw';
-export { default as drawInvalidated } from './drawInvalidated';
-export { default as enable } from './enable';
-export { getElementData, removeElementData } from './enabledElementData';
+export { default as canvasToPixel } from './canvasToPixel.js';
+export { default as disable } from './disable.js';
+export { default as displayImage } from './displayImage.js';
+export { default as draw } from './draw.js';
+export { default as drawInvalidated } from './drawInvalidated.js';
+export { default as enable } from './enable.js';
+export { getElementData, removeElementData } from './enabledElementData.js';
 export {
   getEnabledElement,
   addEnabledElement,
   getEnabledElementsByImageId,
   getEnabledElements
-} from './enabledElements';
-export { default as fitToWindow } from './fitToWindow';
-export { default as getDefaultViewportForImage } from './getDefaultViewportForImage';
-export { default as getImage } from './getImage';
-export { default as getPixels } from './getPixels';
-export { default as getStoredPixels } from './getStoredPixels';
-export { default as getViewport } from './getViewport';
+} from './enabledElements.js';
+export { default as fitToWindow } from './fitToWindow.js';
+export { default as getDefaultViewportForImage } from './getDefaultViewportForImage.js';
+export { default as getImage } from './getImage.js';
+export { default as getPixels } from './getPixels.js';
+export { default as getStoredPixels } from './getStoredPixels.js';
+export { default as getViewport } from './getViewport.js';
 export {
   loadImage,
   loadAndCacheImage,
   registerImageLoader,
   registerUnknownImageLoader
-} from './imageLoader';
+} from './imageLoader.js';
 
-export { default as invalidate } from './invalidate';
-export { default as invalidateImageId } from './invalidateImageId';
-export { default as pageToPixel } from './pageToPixel';
-export { default as pixelToCanvas } from './pixelToCanvas';
-export { default as reset } from './reset';
-export { default as resize } from './resize';
-export { default as setToPixelCoordinateSystem } from './setToPixelCoordinateSystem';
-export { default as setViewport } from './setViewport';
-export { default as updateImage } from './updateImage';
-export { default as pixelDataToFalseColorData } from './pixelDataToFalseColorData';
+export { default as invalidate } from './invalidate.js';
+export { default as invalidateImageId } from './invalidateImageId.js';
+export { default as pageToPixel } from './pageToPixel.js';
+export { default as pixelToCanvas } from './pixelToCanvas.js';
+export { default as reset } from './reset.js';
+export { default as resize } from './resize.js';
+export { default as setToPixelCoordinateSystem } from './setToPixelCoordinateSystem.js';
+export { default as setViewport } from './setViewport.js';
+export { default as updateImage } from './updateImage.js';
+export { default as pixelDataToFalseColorData } from './pixelDataToFalseColorData.js';
 
-export { default as rendering } from './rendering/index';
-export { default as imageCache } from './imageCache';
-export { default as metaData } from './metaData';
-export { default as webGL } from './webgl/index';
-export { default as colors } from './colors/index';
+export { default as rendering } from './rendering/index.js';
+export { default as imageCache } from './imageCache.js';
+export { default as metaData } from './metaData.js';
+export { default as webGL } from './webgl/index.js';
+export { default as colors } from './colors/index.js';
 
 export { convertImageToFalseColorImage,
   convertToFalseColorImage,
-  restoreImage } from './falseColorMapping';
+  restoreImage } from './falseColorMapping.js';
 
-export { default as events } from './events';
+export { default as events } from './events.js';

--- a/src/internal/index.js
+++ b/src/internal/index.js
@@ -1,12 +1,12 @@
-import { default as drawImage } from './drawImage';
-import { default as generateLut } from './generateLut';
-import { default as generateLutNew } from './generateLutNew';
-import { default as getDefaultViewport } from './getDefaultViewport';
-import { default as requestAnimationFrame } from './requestAnimationFrame';
-import { default as storedPixelDataToCanvasImageData } from './storedPixelDataToCanvasImageData';
-import { default as storedColorPixelDataToCanvasImageData } from './storedColorPixelDataToCanvasImageData';
-import { default as getTransform } from './getTransform';
-import { default as calculateTransform } from './calculateTransform';
+import { default as drawImage } from './drawImage.js';
+import { default as generateLut } from './generateLut.js';
+import { default as generateLutNew } from './generateLutNew.js';
+import { default as getDefaultViewport } from './getDefaultViewport.js';
+import { default as requestAnimationFrame } from './requestAnimationFrame.js';
+import { default as storedPixelDataToCanvasImageData } from './storedPixelDataToCanvasImageData.js';
+import { default as storedColorPixelDataToCanvasImageData } from './storedColorPixelDataToCanvasImageData.js';
+import { default as getTransform } from './getTransform.js';
+import { default as calculateTransform } from './calculateTransform.js';
 import { Transform } from './transform.js';
 
 

--- a/src/internal/storedColorPixelDataToCanvasImageData.js
+++ b/src/internal/storedColorPixelDataToCanvasImageData.js
@@ -1,4 +1,4 @@
-import now from './now';
+import now from './now.js';
 
 /**
  * Converts stored color pixel values to display pixel values using a LUT.

--- a/src/internal/storedPixelDataToCanvasImageData.js
+++ b/src/internal/storedPixelDataToCanvasImageData.js
@@ -1,4 +1,4 @@
-import now from './now';
+import now from './now.js';
 
 /**
  * This function transforms stored pixel values into a canvas image data buffer

--- a/src/pixelDataToFalseColorData.js
+++ b/src/pixelDataToFalseColorData.js
@@ -1,4 +1,4 @@
-import colors from './colors/index';
+import colors from './colors/index.js';
 
 /**
  * Converts the image pixel data into a false color data

--- a/src/rendering/index.js
+++ b/src/rendering/index.js
@@ -1,6 +1,6 @@
-import { renderColorImage } from './renderColorImage';
-import { renderGrayscaleImage } from './renderGrayscaleImage';
-import { renderWebImage } from './renderWebImage';
+import { renderColorImage } from './renderColorImage.js';
+import { renderGrayscaleImage } from './renderGrayscaleImage.js';
+import { renderWebImage } from './renderWebImage.js';
 
 export default {
   colorImage: renderColorImage,

--- a/src/rendering/renderColorImage.js
+++ b/src/rendering/renderColorImage.js
@@ -2,9 +2,9 @@
  * This module is responsible for drawing an image to an enabled elements canvas element
  */
 import generateLut from '../internal/generateLut.js';
-import storedColorPixelDataToCanvasImageData from '../internal/storedColorPixelDataToCanvasImageData';
-import setToPixelCoordinateSystem from '../setToPixelCoordinateSystem';
-import webGL from '../webgl/';
+import storedColorPixelDataToCanvasImageData from '../internal/storedColorPixelDataToCanvasImageData.js';
+import setToPixelCoordinateSystem from '../setToPixelCoordinateSystem.js';
+import webGL from '../webgl/index.js';
 
 function initializeColorRenderCanvas (enabledElement, image) {
   const colorRenderCanvas = enabledElement.renderingTools.colorRenderCanvas;

--- a/src/rendering/renderGrayscaleImage.js
+++ b/src/rendering/renderGrayscaleImage.js
@@ -2,10 +2,10 @@
  * This module is responsible for drawing a grayscale image
  */
 import generateLut from '../internal/generateLut.js';
-import storedPixelDataToCanvasImageData from '../internal/storedPixelDataToCanvasImageData';
-import setToPixelCoordinateSystem from '../setToPixelCoordinateSystem';
-import now from '../internal/now';
-import webGL from '../webgl/';
+import storedPixelDataToCanvasImageData from '../internal/storedPixelDataToCanvasImageData.js';
+import setToPixelCoordinateSystem from '../setToPixelCoordinateSystem.js';
+import now from '../internal/now.js';
+import webGL from '../webgl/index.js';
 
 function initializeGrayscaleRenderCanvas (enabledElement, image) {
   const grayscaleRenderCanvas = enabledElement.renderingTools.grayscaleRenderCanvas;

--- a/src/rendering/renderWebImage.js
+++ b/src/rendering/renderWebImage.js
@@ -1,8 +1,8 @@
 /**
  * This module is responsible for drawing an image to an enabled elements canvas element
  */
-import setToPixelCoordinateSystem from '../setToPixelCoordinateSystem';
-import { renderColorImage } from './renderColorImage';
+import setToPixelCoordinateSystem from '../setToPixelCoordinateSystem.js';
+import { renderColorImage } from './renderColorImage.js';
 
 /**
  * API function to draw a standard web image (PNG, JPG) to an enabledImage

--- a/src/webgl/index.js
+++ b/src/webgl/index.js
@@ -1,6 +1,6 @@
-import { render, initRenderer, getRenderCanvas, isWebGLAvailable, isWebGLInitialized } from './renderer';
-import createProgramFromString from './createProgramFromString';
-import textureCache from './textureCache';
+import { render, initRenderer, getRenderCanvas, isWebGLAvailable, isWebGLInitialized } from './renderer.js';
+import createProgramFromString from './createProgramFromString.js';
+import textureCache from './textureCache.js';
 
 export default {
   createProgramFromString,

--- a/src/webgl/renderer.js
+++ b/src/webgl/renderer.js
@@ -1,9 +1,9 @@
 /* eslint no-bitwise: 0 */
 
 import { shaders, dataUtilities } from './shaders/index.js';
-import { vertexShader } from './vertexShader';
-import textureCache from './textureCache';
-import createProgramFromString from './createProgramFromString';
+import { vertexShader } from './vertexShader.js';
+import textureCache from './textureCache.js';
+import createProgramFromString from './createProgramFromString.js';
 
 const renderCanvas = document.createElement('canvas');
 let gl;

--- a/src/webgl/shaders/index.js
+++ b/src/webgl/shaders/index.js
@@ -1,8 +1,8 @@
-import { int16Shader, int16DataUtilities } from './int16';
-import { int8Shader, int8DataUtilities } from './int8';
-import { rgbShader, rgbDataUtilities } from './rgb';
-import { uint16Shader, uint16DataUtilities } from './uint16';
-import { uint8Shader, uint8DataUtilities } from './uint8';
+import { int16Shader, int16DataUtilities } from './int16.js';
+import { int8Shader, int8DataUtilities } from './int8.js';
+import { rgbShader, rgbDataUtilities } from './rgb.js';
+import { uint16Shader, uint16DataUtilities } from './uint16.js';
+import { uint8Shader, uint8DataUtilities } from './uint8.js';
 
 const shaders = {
   int16: int16Shader,

--- a/test/coverage_test.js
+++ b/test/coverage_test.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-unused-expressions */
 import { expect } from 'chai';
 
-import * as cornerstone from '../src/index';
+import * as cornerstone from '../src/index.js';
 
 describe('A test that pulls in all modules', function () {
   it('pulls in all modules', function () {

--- a/test/disable_test.js
+++ b/test/disable_test.js
@@ -1,8 +1,8 @@
 import { assert } from 'chai';
 
-import enable from '../src/enable';
-import disable from '../src/disable';
-import { getEnabledElement, getEnabledElements } from '../src/enabledElements';
+import enable from '../src/enable.js';
+import disable from '../src/disable.js';
+import { getEnabledElement, getEnabledElements } from '../src/enabledElements.js';
 
 describe('Disable an Element', function () {
   beforeEach(function () {

--- a/test/displayImage_test.js
+++ b/test/displayImage_test.js
@@ -1,9 +1,9 @@
 import { assert } from 'chai';
 
-import enable from '../src/enable';
-import displayImage from '../src/displayImage';
-import disable from '../src/disable';
-import { getEnabledElement } from '../src/enabledElements';
+import enable from '../src/enable.js';
+import displayImage from '../src/displayImage.js';
+import disable from '../src/disable.js';
+import { getEnabledElement } from '../src/enabledElements.js';
 
 describe('Display an image', function () {
   beforeEach(function () {

--- a/test/drawInvalidated_test.js
+++ b/test/drawInvalidated_test.js
@@ -1,10 +1,10 @@
 import { assert } from 'chai';
 
-import enable from '../src/enable';
-import displayImage from '../src/displayImage';
-import drawInvalidated from '../src/drawInvalidated';
-import disable from '../src/disable';
-import { getEnabledElement } from '../src/enabledElements';
+import enable from '../src/enable.js';
+import displayImage from '../src/displayImage.js';
+import drawInvalidated from '../src/drawInvalidated.js';
+import disable from '../src/disable.js';
+import { getEnabledElement } from '../src/enabledElements.js';
 
 describe('drawInvalidated', function () {
   beforeEach(function () {

--- a/test/draw_test.js
+++ b/test/draw_test.js
@@ -1,9 +1,9 @@
 import { assert } from 'chai';
 
-import enable from '../src/enable';
-import displayImage from '../src/displayImage';
-import draw from '../src/draw';
-import disable from '../src/disable';
+import enable from '../src/enable.js';
+import displayImage from '../src/displayImage.js';
+import draw from '../src/draw.js';
+import disable from '../src/disable.js';
 
 describe('draw', function () {
   beforeEach(function () {

--- a/test/enable_test.js
+++ b/test/enable_test.js
@@ -1,8 +1,8 @@
 import { assert } from 'chai';
 
-import enable from '../src/enable';
-import disable from '../src/disable';
-import { getEnabledElement, getEnabledElements } from '../src/enabledElements';
+import enable from '../src/enable.js';
+import disable from '../src/disable.js';
+import { getEnabledElement, getEnabledElements } from '../src/enabledElements.js';
 
 describe('Enable a DOM Element for Canvas Renderer', function () {
   beforeEach(function () {

--- a/test/fitToWindow_test.js
+++ b/test/fitToWindow_test.js
@@ -1,11 +1,11 @@
 import { assert } from 'chai';
 
-import enable from '../src/enable';
-import displayImage from '../src/displayImage';
-import fitToWindow from '../src/fitToWindow';
-import setViewport from '../src/setViewport';
-import getViewport from '../src/getViewport';
-import disable from '../src/disable';
+import enable from '../src/enable.js';
+import displayImage from '../src/displayImage.js';
+import fitToWindow from '../src/fitToWindow.js';
+import setViewport from '../src/setViewport.js';
+import getViewport from '../src/getViewport.js';
+import disable from '../src/disable.js';
 
 describe('fitToWindow', function () {
   beforeEach(function () {

--- a/test/getImage_test.js
+++ b/test/getImage_test.js
@@ -1,9 +1,9 @@
 import { assert } from 'chai';
 
-import enable from '../src/enable';
-import displayImage from '../src/displayImage';
-import getImage from '../src/getImage';
-import disable from '../src/disable';
+import enable from '../src/enable.js';
+import displayImage from '../src/displayImage.js';
+import getImage from '../src/getImage.js';
+import disable from '../src/disable.js';
 
 describe('getImage', function () {
   beforeEach(function () {

--- a/test/getPixels_test.js
+++ b/test/getPixels_test.js
@@ -1,9 +1,9 @@
 import { assert } from 'chai';
 
-import enable from '../src/enable';
-import displayImage from '../src/displayImage';
-import getPixels from '../src/getPixels';
-import disable from '../src/disable';
+import enable from '../src/enable.js';
+import displayImage from '../src/displayImage.js';
+import getPixels from '../src/getPixels.js';
+import disable from '../src/disable.js';
 
 describe('getPixels', function () {
   beforeEach(function () {

--- a/test/getStoredPixels_test.js
+++ b/test/getStoredPixels_test.js
@@ -1,9 +1,9 @@
 import { assert } from 'chai';
 
-import enable from '../src/enable';
-import displayImage from '../src/displayImage';
-import getStoredPixels from '../src/getStoredPixels';
-import disable from '../src/disable';
+import enable from '../src/enable.js';
+import displayImage from '../src/displayImage.js';
+import getStoredPixels from '../src/getStoredPixels.js';
+import disable from '../src/disable.js';
 
 describe('getStoredPixels', function () {
   beforeEach(function () {

--- a/test/getViewport_test.js
+++ b/test/getViewport_test.js
@@ -1,8 +1,8 @@
 import { assert } from 'chai';
 
-import enable from '../src/enable';
-import getViewport from '../src/getViewport';
-import disable from '../src/disable';
+import enable from '../src/enable.js';
+import getViewport from '../src/getViewport.js';
+import disable from '../src/disable.js';
 
 describe('Set an enabled element\'s viewport', function () {
   beforeEach(function () {

--- a/test/imageCache_test.js
+++ b/test/imageCache_test.js
@@ -7,9 +7,9 @@ import { setMaximumSizeBytes,
          removeImagePromise,
          getCacheInfo,
          purgeCache,
-         changeImageIdCacheSize } from '../src/imageCache';
+         changeImageIdCacheSize } from '../src/imageCache.js';
 
-import events from '../src/events';
+import events from '../src/events.js';
 
 describe('Set maximum cache size', function () {
   it('should allow setting of cache size', function () {

--- a/test/internal/generateLutNew_test.js
+++ b/test/internal/generateLutNew_test.js
@@ -1,6 +1,6 @@
 import { assert } from 'chai';
 
-import generateLutNew from '../../src/internal/generateLutNew';
+import generateLutNew from '../../src/internal/generateLutNew.js';
 
 describe('generateLutNew', function () {
   beforeEach(function () {

--- a/test/internal/generateLut_test.js
+++ b/test/internal/generateLut_test.js
@@ -1,6 +1,6 @@
 import { assert } from 'chai';
 
-import generateLut from '../../src/internal/generateLut';
+import generateLut from '../../src/internal/generateLut.js';
 
 describe('generateLut', function () {
   it('min pixel < 0', function () {

--- a/test/internal/getModalityLUT_test.js
+++ b/test/internal/getModalityLUT_test.js
@@ -1,6 +1,6 @@
 import { assert } from 'chai';
 
-import getModalityLUT from '../../src/internal/getModalityLUT';
+import getModalityLUT from '../../src/internal/getModalityLUT.js';
 
 describe('getModalityLUT', function () {
   beforeEach(function () {

--- a/test/internal/getVOILut_test.js
+++ b/test/internal/getVOILut_test.js
@@ -1,6 +1,6 @@
 import { assert } from 'chai';
 
-import getVOILut from '../../src/internal/getVOILut';
+import getVOILut from '../../src/internal/getVOILut.js';
 
 describe('getVOILut', function () {
   beforeEach(function () {

--- a/test/internal/storedPixelDataToCanvasImageData_test.js
+++ b/test/internal/storedPixelDataToCanvasImageData_test.js
@@ -1,6 +1,6 @@
 import { assert } from 'chai';
 
-import storedPixelDataToCanvasImageData from '../../src/internal/storedPixelDataToCanvasImageData';
+import storedPixelDataToCanvasImageData from '../../src/internal/storedPixelDataToCanvasImageData.js';
 
 describe('storedPixelDataToCanvasImageData', function () {
   it('storedPixelDataToCanvasImageData minPixel = 0', function () {

--- a/test/invalidateImageId_test.js
+++ b/test/invalidateImageId_test.js
@@ -1,10 +1,10 @@
 import { assert } from 'chai';
 
-import enable from '../src/enable';
-import displayImage from '../src/displayImage';
-import invalidateImageId from '../src/invalidateImageId';
-import disable from '../src/disable';
-import { getEnabledElement } from '../src/enabledElements';
+import enable from '../src/enable.js';
+import displayImage from '../src/displayImage.js';
+import invalidateImageId from '../src/invalidateImageId.js';
+import disable from '../src/disable.js';
+import { getEnabledElement } from '../src/enabledElements.js';
 
 describe('invalidateImageId', function () {
   beforeEach(function () {

--- a/test/invalidated_test.js
+++ b/test/invalidated_test.js
@@ -1,10 +1,10 @@
 import { assert } from 'chai';
 
-import enable from '../src/enable';
-import displayImage from '../src/displayImage';
-import invalidate from '../src/invalidate';
-import disable from '../src/disable';
-import { getEnabledElement } from '../src/enabledElements';
+import enable from '../src/enable.js';
+import displayImage from '../src/displayImage.js';
+import invalidate from '../src/invalidate.js';
+import disable from '../src/disable.js';
+import { getEnabledElement } from '../src/enabledElements.js';
 
 describe('invalidate', function () {
   beforeEach(function () {

--- a/test/reset_test.js
+++ b/test/reset_test.js
@@ -1,12 +1,12 @@
 import { assert } from 'chai';
 
-import enable from '../src/enable';
-import displayImage from '../src/displayImage';
-import reset from '../src/reset';
-import getDefaultViewport from '../src/internal/getDefaultViewport';
-import getViewport from '../src/getViewport';
-import disable from '../src/disable';
-import { getEnabledElement } from '../src/enabledElements';
+import enable from '../src/enable.js';
+import displayImage from '../src/displayImage.js';
+import reset from '../src/reset.js';
+import getDefaultViewport from '../src/internal/getDefaultViewport.js';
+import getViewport from '../src/getViewport.js';
+import disable from '../src/disable.js';
+import { getEnabledElement } from '../src/enabledElements.js';
 
 describe('reset', function () {
   beforeEach(function () {

--- a/test/setViewport_test.js
+++ b/test/setViewport_test.js
@@ -1,10 +1,10 @@
 import { assert } from 'chai';
 
-import enable from '../src/enable';
-import displayImage from '../src/displayImage';
-import setViewport from '../src/setViewport';
-import getViewport from '../src/getViewport';
-import disable from '../src/disable';
+import enable from '../src/enable.js';
+import displayImage from '../src/displayImage.js';
+import setViewport from '../src/setViewport.js';
+import getViewport from '../src/getViewport.js';
+import disable from '../src/disable.js';
 
 const MIN_WINDOW_WIDTH = 0.000001;
 const MIN_VIEWPORT_SCALE = 0.0001;

--- a/test/updateImage_test.js
+++ b/test/updateImage_test.js
@@ -1,9 +1,9 @@
 import { assert } from 'chai';
 
-import enable from '../src/enable';
-import displayImage from '../src/displayImage';
-import updateImage from '../src/updateImage';
-import disable from '../src/disable';
+import enable from '../src/enable.js';
+import displayImage from '../src/displayImage.js';
+import updateImage from '../src/updateImage.js';
+import disable from '../src/disable.js';
 
 describe('Update a displayed image', function () {
   beforeEach(function () {


### PR DESCRIPTION
Adds '.js' extenstions where missing in import/export commands

This is necessary to allow correct html module load with 
`<script type="module" src="cornerstone/index.js"></script>`
which allows using cornerstone sources directly without webpack.

Note that ATM type module requires chrome beta and in chrome://flags/ enabling 'Experimental Web Platform features' (see https://jakearchibald.com/2017/es-modules-in-browsers)
