### PR TITLE
external imports

### DIFF
--- a/src/disable.js
+++ b/src/disable.js
@@ -1,4 +1,4 @@
-import $ from './jquery.js';
+import { $ } from './externalImports.js';
 import { getEnabledElements } from './enabledElements.js';
 
 /**

--- a/src/displayImage.js
+++ b/src/displayImage.js
@@ -1,4 +1,4 @@
-import $ from './jquery.js';
+import { $ } from './externalImports.js';
 import { getEnabledElement } from './enabledElements.js';
 import getDefaultViewport from './internal/getDefaultViewport.js';
 import updateImage from './updateImage.js';

--- a/src/enable.js
+++ b/src/enable.js
@@ -1,13 +1,13 @@
-/**
- * This module is responsible for enabling an element to display images with cornerstone
- */
-
-import $ from './jquery.js';
+import { $ } from './externalImports.js';
 import { addEnabledElement } from './enabledElements.js';
 import resize from './resize.js';
 import drawImageSync from './internal/drawImageSync.js';
 import requestAnimationFrame from './internal/requestAnimationFrame.js';
 import webGL from './webgl/index.js';
+
+/**
+ * This module is responsible for enabling an element to display images with cornerstone
+ */
 
 function hasImageOrLayers (enabledElement) {
   return enabledElement.image !== undefined || enabledElement.layers.length;

--- a/src/externalImports.js
+++ b/src/externalImports.js
@@ -1,0 +1,3 @@
+import * as $ from 'jquery';
+
+export { $ };

--- a/src/externalImportsES6modules.js
+++ b/src/externalImportsES6modules.js
@@ -1,0 +1,3 @@
+const $=window.$;
+
+export { $ };

--- a/src/imageCache.js
+++ b/src/imageCache.js
@@ -1,3 +1,6 @@
+import { $ } from './externalImports.js';
+import events from './events.js';
+
 /**
  * This module deals with caching images
  */
@@ -9,9 +12,6 @@ const imageCacheDict = {};
 
 // Array of cachedImage objects
 export const cachedImages = [];
-
-import $ from './jquery.js';
-import events from './events.js';
 
 export function setMaximumSizeBytes (numBytes) {
   if (numBytes === undefined) {

--- a/src/imageLoader.js
+++ b/src/imageLoader.js
@@ -1,10 +1,10 @@
+import { $ } from './externalImports.js';
+import { getImagePromise, putImagePromise } from './imageCache.js';
+import events from './events.js';
+
 /**
  * This module deals with ImageLoaders, loading images and caching images
  */
-
-import $ from './jquery.js';
-import { getImagePromise, putImagePromise } from './imageCache.js';
-import events from './events.js';
 
 const imageLoaders = {};
 

--- a/src/internal/drawImageSync.js
+++ b/src/internal/drawImageSync.js
@@ -1,4 +1,4 @@
-import $ from '../jquery.js';
+import { $ } from '../externalImports.js';
 import now from './now.js';
 import drawCompositeImage from './drawCompositeImage.js';
 import { renderColorImage } from '../rendering/renderColorImage.js';

--- a/src/internal/storedColorPixelDataToCanvasImageData.js
+++ b/src/internal/storedColorPixelDataToCanvasImageData.js
@@ -1,4 +1,4 @@
-import now from './now';
+import now from './now.js';
 
 /**
  * Converts stored color pixel values to display pixel values using a LUT.

--- a/src/invalidate.js
+++ b/src/invalidate.js
@@ -1,9 +1,9 @@
+import { $ } from './externalImports.js';
+import { getEnabledElement } from './enabledElements.js';
+
 /**
  * This module contains a function to make an image is invalid
  */
-
-import $ from './jquery.js';
-import { getEnabledElement } from './enabledElements.js';
 
 /**
  * Sets the invalid flag on the enabled element and fire an event

--- a/src/jquery.js
+++ b/src/jquery.js
@@ -1,7 +1,0 @@
-/*
- * When loading sources directly with <script type="module"> remove the line below
- * (keep only the export line)
- */
-import $ from 'jquery';
-
-export default $;

--- a/src/layers.js
+++ b/src/layers.js
@@ -1,4 +1,4 @@
-import $ from './jquery.js';
+import { $ } from './externalImports.js';
 import guid from './internal/guid.js';
 import { getEnabledElement } from './enabledElements.js';
 import metaData from './metaData.js';

--- a/src/resize.js
+++ b/src/resize.js
@@ -1,4 +1,4 @@
-import $ from './jquery.js';
+import { $ } from './externalImports.js';
 import { getEnabledElement } from './enabledElements.js';
 import fitToWindow from './fitToWindow.js';
 import updateImage from './updateImage.js';

--- a/src/webgl/textureCache.js
+++ b/src/webgl/textureCache.js
@@ -1,4 +1,4 @@
-import $ from '../jquery.js';
+import { $ } from '../externalImports.js';
 import events from '../events.js';
 
 /**


### PR DESCRIPTION
This PR removes jquery.js and adds two files: externalImports.js and externalImportsES6modules.js

externalImportsES6modules.js is never used.  When direct loading ES6 modules, simply backup and replace externalImports.js with externalImportsES6modules.js, and replace back before creating a packaged build.

All imports were moved to the beginning of the file as seems to be required by chrome/standard.

(This PR also converts some CRLF to LF which got messed up on the original es6 modules PR.)

 