### PR TITLE
OHIF-148: forcing new LUT generation after applying false color mapping

### DIFF
--- a/src/pixelDataToFalseColorData.js
+++ b/src/pixelDataToFalseColorData.js
@@ -56,7 +56,8 @@ export default function (image, lookupTable) {
   }
 
   image.rgba = true;
-  image.lut = undefined;
+  image.cachedLut = undefined;
+  image.render = undefined;
   image.slope = 1;
   image.intercept = 0;
   image.minPixelValue = 0;


### PR DESCRIPTION
# Issue
Using `pixelDataToFalseColorData` would case grayscale image to go blank. This issue was caused by:
 1 - If you are using the `cornerstoneWADOImageLoader` it actually sets a default renderer to the image [createImage](https://github.com/chafey/cornerstoneWADOImageLoader/blob/4172f78bb703a3d33e0c42fb598089127910059c/src/imageLoader/createImage.js#L117) causing cornerstone to use the wrong renderer [drawImageSync](https://github.com/chafey/cornerstone/blob/master/src/internal/drawImageSync.js#L40);
 2 - And, after applying the false color map we were not generating the LUT again, using the one created with the gray scale pixel data [renderColorImage](https://github.com/chafey/cornerstone/blob/master/src/rendering/renderColorImage.js#L31)

# Solution
After applying the false color image we need to reset the LUT and the renderer and after that we should see the right image

This PR addresses #148 
# Demo
![falseimage](https://user-images.githubusercontent.com/5274353/31548799-834dcff0-b002-11e7-8ae4-6976bad0a7e9.gif)
