### PR TITLE
trigger custom events in addition to jquery events

### DIFF
--- a/src/disable.js
+++ b/src/disable.js
@@ -1,5 +1,7 @@
 import { $ } from './externalModules.js';
 import { getEnabledElements } from './enabledElements.js';
+import triggerEvent from './triggerEvent.js';
+
 
 /**
  *  Disable an HTML element for further use in Cornerstone
@@ -25,6 +27,7 @@ export default function (element) {
       };
 
       $(element).trigger('CornerstoneElementDisabled', eventData);
+      triggerEvent(element, 'CornerstoneElementDisabled', eventData);
 
       // Remove the child DOM elements that we created (e.g.canvas)
       enabledElements[i].element.removeChild(enabledElements[i].canvas);

--- a/src/displayImage.js
+++ b/src/displayImage.js
@@ -4,6 +4,7 @@ import getDefaultViewport from './internal/getDefaultViewport.js';
 import updateImage from './updateImage.js';
 import now from './internal/now.js';
 import { getActiveLayer } from './layers.js';
+import triggerEvent from './triggerEvent.js';
 
 /**
  * Sets a new image object for a given element.
@@ -67,6 +68,7 @@ export default function (element, image, viewport) {
   };
 
   $(enabledElement.element).trigger('CornerstoneNewImage', newImageEventData);
+  triggerEvent(enabledElement.element, 'CornerstoneNewImage', newImageEventData);
 
   updateImage(element);
 }

--- a/src/enable.js
+++ b/src/enable.js
@@ -4,6 +4,7 @@ import resize from './resize.js';
 import drawImageSync from './internal/drawImageSync.js';
 import requestAnimationFrame from './internal/requestAnimationFrame.js';
 import webGL from './webgl/index.js';
+import triggerEvent from './triggerEvent.js';
 
 /**
  * This module is responsible for enabling an element to display images with cornerstone
@@ -74,10 +75,13 @@ export default function (element, options) {
       return;
     }
 
-    $(enabledElement.element).trigger('CornerstonePreRender', {
+    const eventDetails = {
       enabledElement,
       timestamp
-    });
+    };
+
+    $(enabledElement.element).trigger('CornerstonePreRender', eventDetails);
+    triggerEvent(enabledElement.element, 'CornerstonePreRender', eventDetails);
 
     if (enabledElement.needsRedraw && hasImageOrLayers(enabledElement)) {
       drawImageSync(enabledElement, enabledElement.invalid);

--- a/src/imageCache.js
+++ b/src/imageCache.js
@@ -1,5 +1,6 @@
 import { $ } from './externalModules.js';
 import events from './events.js';
+import triggerEvent from './triggerEvent.js';
 
 /**
  * This module deals with caching images
@@ -23,6 +24,7 @@ export function setMaximumSizeBytes (numBytes) {
 
   maximumSizeInBytes = numBytes;
   $(events).trigger('CornerstoneImageCacheMaximumSizeChanged');
+  triggerEvent(events, 'CornerstoneImageCacheMaximumSizeChanged');
   purgeCacheIfNecessary();
 }
 
@@ -54,11 +56,13 @@ function purgeCacheIfNecessary () {
     removeImagePromise(imageId);
 
     $(events).trigger('CornerstoneImageCachePromiseRemoved', { imageId });
+    triggerEvent(events, 'CornerstoneImageCachePromiseRemoved', { imageId });
   }
 
   const cacheInfo = getCacheInfo();
 
   $(events).trigger('CornerstoneImageCacheFull', cacheInfo);
+  triggerEvent(events, 'CornerstoneImageCacheFull', cacheInfo);
 }
 
 export function putImagePromise (imageId, imagePromise) {
@@ -102,10 +106,15 @@ export function putImagePromise (imageId, imagePromise) {
 
     cachedImage.sizeInBytes = image.sizeInBytes;
     cacheSizeInBytes += cachedImage.sizeInBytes;
-    $(events).trigger('CornerstoneImageCacheChanged', {
+
+    const eventDetails = {
       action: 'addImage',
       image: cachedImage
-    });
+    };
+
+    $(events).trigger('CornerstoneImageCacheChanged', eventDetails);
+    triggerEvent(events, 'CornerstoneImageCacheChanged', eventDetails);
+
     cachedImage.sharedCacheKey = image.sharedCacheKey;
 
     purgeCacheIfNecessary();
@@ -141,10 +150,14 @@ export function removeImagePromise (imageId) {
   cachedImage.imagePromise.reject();
   cachedImages.splice(cachedImages.indexOf(cachedImage), 1);
   cacheSizeInBytes -= cachedImage.sizeInBytes;
-  $(events).trigger('CornerstoneImageCacheChanged', {
+
+  const eventDetails = {
     action: 'deleteImage',
     image: cachedImage
-  });
+  };
+
+  $(events).trigger('CornerstoneImageCacheChanged', eventDetails);
+  triggerEvent(events, 'CornerstoneImageCacheChanged', eventDetails);
   decache(cachedImage.imagePromise);
 
   delete imageCacheDict[imageId];
@@ -186,10 +199,13 @@ export function changeImageIdCacheSize (imageId, newCacheSize) {
       image.sizeInBytes = newCacheSize;
       cacheEntry.sizeInBytes = newCacheSize;
       cacheSizeInBytes += cacheSizeDifference;
-      $(events).trigger('CornerstoneImageCacheChanged', {
+      const eventDetails = {
         action: 'changeImageSize',
         image
-      });
+      };
+
+      $(events).trigger('CornerstoneImageCacheChanged', eventDetails);
+      triggerEvent(events, 'CornerstoneImageCacheChanged', eventDetails);
     });
   }
 }

--- a/src/imageLoader.js
+++ b/src/imageLoader.js
@@ -1,6 +1,7 @@
 import { $ } from './externalModules.js';
 import { getImagePromise, putImagePromise } from './imageCache.js';
 import events from './events.js';
+import triggerEvent from './triggerEvent.js';
 
 /**
  * This module deals with ImageLoaders, loading images and caching images
@@ -43,6 +44,7 @@ function loadImageFromImageLoader (imageId, options) {
   // Broadcast an image loaded event once the image is loaded
   imagePromise.then(function (image) {
     $(events).trigger('CornerstoneImageLoaded', { image });
+    triggerEvent(events, 'CornerstoneImageLoaded', { image });
   });
 
   return imagePromise;

--- a/src/internal/drawImageSync.js
+++ b/src/internal/drawImageSync.js
@@ -3,6 +3,7 @@ import now from './now.js';
 import drawCompositeImage from './drawCompositeImage.js';
 import { renderColorImage } from '../rendering/renderColorImage.js';
 import { renderGrayscaleImage } from '../rendering/renderGrayscaleImage.js';
+import triggerEvent from '../triggerEvent.js';
 
 /**
  * Draw an image to a given enabled element synchronously
@@ -62,4 +63,5 @@ export default function (enabledElement, invalidated) {
   enabledElement.needsRedraw = false;
 
   $(element).trigger('CornerstoneImageRendered', eventData);
+  triggerEvent(element, 'CornerstoneImageRendered', eventData);
 }

--- a/src/invalidate.js
+++ b/src/invalidate.js
@@ -1,5 +1,6 @@
 import { $ } from './externalModules.js';
 import { getEnabledElement } from './enabledElements.js';
+import triggerEvent from './triggerEvent.js';
 
 /**
  * This module contains a function to make an image is invalid
@@ -20,4 +21,5 @@ export default function (element) {
   };
 
   $(element).trigger('CornerstoneInvalidated', eventData);
+  triggerEvent(element, 'CornerstoneInvalidated', eventData);
 }

--- a/src/layers.js
+++ b/src/layers.js
@@ -4,6 +4,7 @@ import { getEnabledElement } from './enabledElements.js';
 import metaData from './metaData.js';
 import getDefaultViewport from './internal/getDefaultViewport.js';
 import updateImage from './updateImage.js';
+import triggerCustomEvent from './triggerEvent.js';
 
 /**
  * Helper function to trigger an event on a Cornerstone element with
@@ -25,6 +26,7 @@ function triggerEvent (eventName, enabledElement, layerId) {
   };
 
   $(element).trigger(eventName, eventData);
+  triggerCustomEvent(element, eventName, eventData);
 }
 
 /**

--- a/src/resize.js
+++ b/src/resize.js
@@ -2,6 +2,7 @@ import { $ } from './externalModules.js';
 import { getEnabledElement } from './enabledElements.js';
 import fitToWindow from './fitToWindow.js';
 import updateImage from './updateImage.js';
+import triggerEvent from './triggerEvent.js';
 
 /**
  * This module is responsible for enabling an element to display images with cornerstone
@@ -62,6 +63,7 @@ export default function (element, fitViewportToWindow) {
   };
 
   $(element).trigger('CornerstoneElementResized', eventData);
+  triggerEvent(element, 'CornerstoneElementResized', eventData);
 
   if (enabledElement.image === undefined) {
     return;

--- a/src/triggerEvent.js
+++ b/src/triggerEvent.js
@@ -1,0 +1,21 @@
+export default function triggerEvent (el, type, detail) {
+  let event;
+
+  type = type.toLocaleLowerCase();
+
+  detail = detail || {};
+
+  if (window.CustomEvent) {
+    event = new CustomEvent(type, { detail });
+  } else {
+    event = document.createEvent('CustomEvent');
+    event.initCustomEvent(type, true, true, detail);
+  }
+
+  if (el.dispatchEvent) {
+    el.dispatchEvent(event);
+  } else {
+    document.dispatchEvent(event);
+  }
+}
+

--- a/src/webgl/textureCache.js
+++ b/src/webgl/textureCache.js
@@ -1,5 +1,6 @@
 import { $ } from '../externalModules.js';
 import events from '../events.js';
+import triggerEvent from '../triggerEvent.js';
 
 /**
  * This module deals with caching image textures in VRAM for WebGL
@@ -49,11 +50,13 @@ function purgeCacheIfNecessary () {
     cachedImages.pop();
 
     $(events).trigger('CornerstoneWebGLTextureRemoved', { imageId: lastCachedImage.imageId });
+    triggerEvent(events, 'CornerstoneWebGLTextureRemoved', { imageId: lastCachedImage.imageId });
   }
 
   const cacheInfo = getCacheInfo();
 
   $(events).trigger('CornerstoneWebGLTextureCacheFull', cacheInfo);
+  triggerEvent(events, 'CornerstoneWebGLTextureCacheFull', cacheInfo);
 }
 
 function setMaximumSizeBytes (numBytes) {


### PR DESCRIPTION
According to the discussion in #180 the first step to removing the jquery events is to trigger native events in addition to the jquery ones.

This PR triggers native events everywhere that jquery events are triggered. All events are also renamed, since they would trigger duplicates otherwise (jquery listens to both jquery and native events alike, but only triggers jquery events).

In order to drop the jquery events, it is also needed to change all listeners, since the event data looks slightly different.

I'm willing to take on converting all the listeners as well, since it solves some bugs I've had with running multiple instances of jQuery, and events not triggering properly.