### PR TITLE
Properly reexport reference to isWebGLInitialized from WebGL module

### DIFF
--- a/src/webgl/index.js
+++ b/src/webgl/index.js
@@ -2,7 +2,7 @@ import { render, initRenderer, getRenderCanvas, isWebGLAvailable, isWebGLInitial
 import createProgramFromString from './createProgramFromString.js';
 import textureCache from './textureCache.js';
 
-export default {
+const mod = {
   createProgramFromString,
   renderer: {
     render,
@@ -10,6 +10,13 @@ export default {
     getRenderCanvas,
     isWebGLAvailable
   },
-  textureCache,
-  isWebGLInitialized
+  textureCache
 };
+
+Object.defineProperty(mod, 'isWebGLInitialized', {
+  enumerable: true,
+  configurable: false,
+  get: () => isWebGLInitialized
+});
+
+export default mod;


### PR DESCRIPTION
Fixes #136

Looks like the problem was the parent module was reexporting a copy of the `false` bool, which then wasn't getting updated when WebGL was enable. This change updates `isWebGLInitialized` to have a getter instead, so the correct value is displayed.