### PR TITLE
Trigger all jQuery events inside triggerEvent function

### DIFF
--- a/src/disable.js
+++ b/src/disable.js
@@ -1,4 +1,3 @@
-import { external } from './externalModules.js';
 import { getEnabledElements } from './enabledElements.js';
 import triggerEvent from './triggerEvent.js';
 
@@ -26,8 +25,6 @@ export default function (element) {
         element
       };
 
-      external.$(element).trigger('CornerstoneElementDisabled', eventData);
-      $(element).trigger('CornerstoneElementDisabled', eventData);
       triggerEvent(element, 'CornerstoneElementDisabled', eventData);
 
       // Remove the child DOM elements that we created (e.g.canvas)

--- a/src/displayImage.js
+++ b/src/displayImage.js
@@ -1,4 +1,3 @@
-import { external } from './externalModules.js';
 import { getEnabledElement } from './enabledElements.js';
 import getDefaultViewport from './internal/getDefaultViewport.js';
 import updateImage from './updateImage.js';
@@ -67,7 +66,6 @@ export default function (element, image, viewport) {
     frameRate
   };
 
-  external.$(enabledElement.element).trigger('CornerstoneNewImage', newImageEventData);
   triggerEvent(enabledElement.element, 'CornerstoneNewImage', newImageEventData);
 
   updateImage(element);

--- a/src/enable.js
+++ b/src/enable.js
@@ -1,4 +1,3 @@
-import { external } from './externalModules.js';
 import { addEnabledElement } from './enabledElements.js';
 import resize from './resize.js';
 import drawImageSync from './internal/drawImageSync.js';
@@ -80,7 +79,6 @@ export default function (element, options) {
       timestamp
     };
 
-    external.$(enabledElement.element).trigger('CornerstonePreRender', eventDetails);
     triggerEvent(enabledElement.element, 'CornerstonePreRender', eventDetails);
 
     if (enabledElement.needsRedraw && hasImageOrLayers(enabledElement)) {

--- a/src/imageCache.js
+++ b/src/imageCache.js
@@ -1,4 +1,3 @@
-import { external } from './externalModules.js';
 import events from './events.js';
 import triggerEvent from './triggerEvent.js';
 
@@ -24,7 +23,6 @@ export function setMaximumSizeBytes (numBytes) {
 
   maximumSizeInBytes = numBytes;
 
-  external.$(events).trigger('CornerstoneImageCacheMaximumSizeChanged');
   triggerEvent(events, 'CornerstoneImageCacheMaximumSizeChanged');
 
   purgeCacheIfNecessary();
@@ -57,13 +55,11 @@ function purgeCacheIfNecessary () {
 
     removeImagePromise(imageId);
 
-    external.$(events).trigger('CornerstoneImageCachePromiseRemoved', { imageId });
     triggerEvent(events, 'CornerstoneImageCachePromiseRemoved', { imageId });
   }
 
   const cacheInfo = getCacheInfo();
 
-  external.$(events).trigger('CornerstoneImageCacheFull', cacheInfo);
   triggerEvent(events, 'CornerstoneImageCacheFull', cacheInfo);
 }
 
@@ -114,7 +110,6 @@ export function putImagePromise (imageId, imagePromise) {
       image: cachedImage
     };
 
-    external.$(events).trigger('CornerstoneImageCacheChanged', eventDetails);
     triggerEvent(events, 'CornerstoneImageCacheChanged', eventDetails);
 
     cachedImage.sharedCacheKey = image.sharedCacheKey;
@@ -158,7 +153,6 @@ export function removeImagePromise (imageId) {
     image: cachedImage
   };
 
-  external.$(events).trigger('CornerstoneImageCacheChanged', eventDetails);
   triggerEvent(events, 'CornerstoneImageCacheChanged', eventDetails);
   decache(cachedImage.imagePromise);
 
@@ -207,7 +201,6 @@ export function changeImageIdCacheSize (imageId, newCacheSize) {
         image
       };
 
-      external.$(events).trigger('CornerstoneImageCacheChanged', eventDetails);
       triggerEvent(events, 'CornerstoneImageCacheChanged', eventDetails);
     });
   }

--- a/src/imageLoader.js
+++ b/src/imageLoader.js
@@ -1,4 +1,3 @@
-import { external } from './externalModules.js';
 import { getImagePromise, putImagePromise } from './imageCache.js';
 import events from './events.js';
 import triggerEvent from './triggerEvent.js';
@@ -43,7 +42,6 @@ function loadImageFromImageLoader (imageId, options) {
 
   // Broadcast an image loaded event once the image is loaded
   imagePromise.then(function (image) {
-    external.$(events).trigger('CornerstoneImageLoaded', { image });
     triggerEvent(events, 'CornerstoneImageLoaded', { image });
   });
 

--- a/src/internal/drawImageSync.js
+++ b/src/internal/drawImageSync.js
@@ -1,4 +1,3 @@
-import { external } from '../externalModules.js';
 import now from './now.js';
 import drawCompositeImage from './drawCompositeImage.js';
 import { renderColorImage } from '../rendering/renderColorImage.js';
@@ -62,6 +61,5 @@ export default function (enabledElement, invalidated) {
   enabledElement.invalid = false;
   enabledElement.needsRedraw = false;
 
-  external.$(element).trigger('CornerstoneImageRendered', eventData);
   triggerEvent(element, 'CornerstoneImageRendered', eventData);
 }

--- a/src/invalidate.js
+++ b/src/invalidate.js
@@ -1,4 +1,3 @@
-import { external } from './externalModules.js';
 import { getEnabledElement } from './enabledElements.js';
 import triggerEvent from './triggerEvent.js';
 
@@ -20,6 +19,5 @@ export default function (element) {
     element
   };
 
-  external.$(element).trigger('CornerstoneInvalidated', eventData);
   triggerEvent(element, 'CornerstoneInvalidated', eventData);
 }

--- a/src/layers.js
+++ b/src/layers.js
@@ -1,4 +1,3 @@
-import { external } from './externalModules.js';
 import guid from './internal/guid.js';
 import { getEnabledElement } from './enabledElements.js';
 import metaData from './metaData.js';
@@ -25,7 +24,6 @@ function triggerEvent (eventName, enabledElement, layerId) {
     layerId
   };
 
-  external.$(element).trigger(eventName, eventData);
   triggerCustomEvent(element, eventName, eventData);
 }
 

--- a/src/resize.js
+++ b/src/resize.js
@@ -1,4 +1,3 @@
-import { external } from './externalModules.js';
 import { getEnabledElement } from './enabledElements.js';
 import fitToWindow from './fitToWindow.js';
 import updateImage from './updateImage.js';
@@ -62,7 +61,6 @@ export default function (element, fitViewportToWindow) {
     element
   };
 
-  external.$(element).trigger('CornerstoneElementResized', eventData);
   triggerEvent(element, 'CornerstoneElementResized', eventData);
 
   if (enabledElement.image === undefined) {

--- a/src/triggerEvent.js
+++ b/src/triggerEvent.js
@@ -1,3 +1,5 @@
+import { external } from './externalModules.js';
+
 /**
  * Trigger a CustomEvent
  *
@@ -7,9 +9,9 @@
  * @returns {void}
  */
 export default function triggerEvent (el, type, detail = null) {
-  type = type.toLocaleLowerCase();
+  const event = new CustomEvent(type.toLocaleLowerCase(), { detail });
 
-  const event = new CustomEvent(type, { detail });
-
+  // TODO: remove jQuery event triggers
+  external.$(el).trigger(type, detail);
   el.dispatchEvent(event);
 }

--- a/src/webgl/textureCache.js
+++ b/src/webgl/textureCache.js
@@ -1,4 +1,3 @@
-import { external } from '../externalModules.js';
 import events from '../events.js';
 import triggerEvent from '../triggerEvent.js';
 
@@ -49,13 +48,11 @@ function purgeCacheIfNecessary () {
     delete imageCache[lastCachedImage.imageId];
     cachedImages.pop();
 
-    external.$(events).trigger('CornerstoneWebGLTextureRemoved', { imageId: lastCachedImage.imageId });
     triggerEvent(events, 'CornerstoneWebGLTextureRemoved', { imageId: lastCachedImage.imageId });
   }
 
   const cacheInfo = getCacheInfo();
 
-  external.$(events).trigger('CornerstoneWebGLTextureCacheFull', cacheInfo);
   triggerEvent(events, 'CornerstoneWebGLTextureCacheFull', cacheInfo);
 }
 


### PR DESCRIPTION
This PR moves all the jQuery triggers inside the triggerEvent functions, which should make it easier to deprecate jQuery later (only change one line of code)