### PR TITLE
Remove jQuery from tests

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -14,6 +14,7 @@ module.exports = function(config) {
     frameworks: ['mocha'],
     reporters: ['progress', 'coverage'],
     files: [
+      'node_modules/promise-polyfill/promise.js',
       'test/*_test.js',
       'test/**/*_test.js'
     ],

--- a/test/disable_test.js
+++ b/test/disable_test.js
@@ -23,13 +23,15 @@ describe('Disable an Element', function () {
     disable(this.element);
   });
 
-  it('should fire CornerstoneElementDisabled', function () {
-    const element = this.element;
+  it('should fire CornerstoneElementDisabled', function (done) {
+    const element = this.element2;
 
     // Assert
-    $(element).on('CornerstoneElementDisabled', function (event, eventData) {
-      assert.equal(eventData.element, element);
+    element.addEventListener('cornerstoneelementdisabled', function (event) {
+      assert.equal(event.target, element);
+      done();
     });
+    disable(element);
   });
 
   it('should no longer be available in the enabledElement array', function () {

--- a/test/displayImage_test.js
+++ b/test/displayImage_test.js
@@ -57,10 +57,10 @@ describe('Display an image', function () {
     const element = this.element;
     const image = this.image;
 
-    $(element).on('CornerstoneNewImage', function (event, eventData) {
+    element.addEventListener('cornerstonenewimage', function (event) {
       // Assert
-      assert.equal(eventData.element, element);
-      assert.equal(eventData.image, image);
+      assert.equal(event.target, element);
+      assert.equal(event.detail.image, image);
       done();
     });
 
@@ -88,17 +88,17 @@ describe('Display an image', function () {
       vflip: true
     };
 
-    $(element).on('CornerstoneNewImage', function (event, eventData) {
+    element.addEventListener('cornerstonenewimage', function (event) {
       // Assert
-      assert.equal(eventData.element, element);
-      assert.equal(eventData.image, image);
+      assert.equal(event.target, element);
+      assert.equal(event.detail.image, image);
 
       // Check that all of the viewport properites we specified are
       // now set in the enabled element's viewport. Use the loop
       // because the enabledElement viewport will have extra properties
       // such as modalityLUT and voiLUT.
       Object.keys(viewport).forEach((key) => {
-        assert.deepEqual(eventData.viewport[key], viewport[key]);
+        assert.deepEqual(event.detail.viewport[key], viewport[key]);
       });
       done();
     });
@@ -134,15 +134,15 @@ describe('Display an image', function () {
     const image = this.image;
     const viewport = this.viewport;
 
-    $(element).on('CornerstoneNewImage', function (event, eventData) {
+    element.addEventListener('cornerstonenewimage', function (event) {
       // Assert
-      assert.equal(eventData.element, element);
-      assert.equal(eventData.image, image);
+      assert.equal(event.target, element);
+      assert.equal(event.detail.image, image);
 
-      if (eventData.frameRate) {
+      if (event.detail.frameRate) {
         // Note: FrameRate is returned as a String since it uses toFixed
-        assert.equal(eventData.frameRate, '1');
-        assert.isDefined(eventData.enabledElement.lastImageTimeStamp);
+        assert.equal(event.detail.frameRate, '1');
+        assert.isDefined(event.detail.enabledElement.lastImageTimeStamp);
         done();
       }
     });

--- a/test/drawInvalidated_test.js
+++ b/test/drawInvalidated_test.js
@@ -74,16 +74,16 @@ describe('drawInvalidated', function () {
     const image2 = this.image2;
 
     // Assert
-    $(element1).on('CornerstoneImageRendered', function () {
+    element1.addEventListener('cornerstoneimagerendered', function () {
       // If element1 is redrawn, then this test has failed.
       // Only element2 should be redrawn.
       done();
     });
 
-    $(element2).on('CornerstoneImageRendered', function (event, eventData) {
+    element2.addEventListener('cornerstoneimagerendered', function (event) {
       // Make sure element2 is redrawn since it has been invalidated
-      assert.equal(eventData.element, element2);
-      assert.equal(eventData.image, image2);
+      assert.equal(event.target, element2);
+      assert.equal(event.detail.image, image2);
       done();
     });
 
@@ -103,18 +103,18 @@ describe('drawInvalidated', function () {
     const image2 = this.image2;
 
     // Assert
-    $(element1).on('CornerstoneImageRendered', function (event, eventData) {
+    element1.addEventListener('cornerstoneimagerendered', function (event) {
       // If element1 is redrawn, then this test has failed.
       // Only element2 should be redrawn.
-      assert.equal(eventData.element, element1);
-      assert.equal(eventData.image, image1);
+      assert.equal(event.target, element1);
+      assert.equal(event.detail.image, image1);
       done();
     });
 
-    $(element2).on('CornerstoneImageRendered', function (event, eventData) {
+    element2.addEventListener('cornerstoneimagerendered', function (event) {
       // Make sure element2 is redrawn since it has been invalidated
-      assert.equal(eventData.element, element2);
-      assert.equal(eventData.image, image2);
+      assert.equal(event.target, element2);
+      assert.equal(event.detail.image, image2);
       done();
     });
 

--- a/test/draw_test.js
+++ b/test/draw_test.js
@@ -46,10 +46,10 @@ describe('draw', function () {
 
     displayImage(this.element, this.image);
 
-    $(element).on('CornerstoneImageRendered', function (event, eventData) {
+    element.addEventListener('cornerstoneimagerendered', function (event) {
       // Assert
-      assert.equal(eventData.element, element);
-      assert.equal(eventData.image, image);
+      assert.equal(event.target, element);
+      assert.equal(event.detail.image, image);
       done();
     });
 

--- a/test/enable_test.js
+++ b/test/enable_test.js
@@ -14,14 +14,22 @@ describe('Enable a DOM Element for Canvas Renderer', function () {
     enable(this.element, options);
   });
 
-  it('should fire CornerstoneImageRendered', function () {
-    const element = this.element;
+  it('should fire CornerstonePreRender', function (done) {
+    // Arrange
+    const element = document.createElement('div');
 
-    // Assert
-    $(element).on('CornerstoneImageRendered', function (event, eventData) {
-      assert.equal(eventData.element, element);
+    element.addEventListener('cornerstoneprerender', function (event) {
+      assert.equal(event.target, element);
+
+      // Cleanup
+      disable(element);
+      done();
     });
 
+    // Act
+    enable(element, {});
+
+    // Assert
     const enabledElement = getEnabledElement(element);
 
     assert.equal(enabledElement.element, element);

--- a/test/internal/drawComposite_test.js
+++ b/test/internal/drawComposite_test.js
@@ -79,9 +79,9 @@ describe('layers', function () {
     addLayer(this.element, this.image1);
     addLayer(this.element, this.image2);
 
-    $(this.element).on('CornerstoneImageRendered', (event, eventData) => {
+    this.element.addEventListener('cornerstoneimagerendered', (event) => {
       // Assert
-      assert.equal(eventData.element, this.element);
+      assert.equal(event.target, this.element);
       done();
     });
 
@@ -96,9 +96,9 @@ describe('layers', function () {
       opacity: 0.7
     });
 
-    $(this.element).on('CornerstoneImageRendered', (event, eventData) => {
+    this.element.addEventListener('cornerstoneimagerendered', (event) => {
       // Assert
-      assert.equal(eventData.element, this.element);
+      assert.equal(event.target, this.element);
       done();
     });
 
@@ -113,9 +113,9 @@ describe('layers', function () {
       colormap: 'Blues'
     });
 
-    $(this.element).on('CornerstoneImageRendered', (event, eventData) => {
+    this.element.addEventListener('cornerstoneimagerendered', (event) => {
       // Assert
-      assert.equal(eventData.element, this.element);
+      assert.equal(event.target, this.element);
       done();
     });
 

--- a/test/invalidated_test.js
+++ b/test/invalidated_test.js
@@ -42,9 +42,9 @@ describe('invalidate', function () {
     const element = this.element;
     const enabledElement = getEnabledElement(this.element);
 
-    $(element).on('CornerstoneInvalidated', function (event, eventData) {
+    element.addEventListener('cornerstoneinvalidated', function (event) {
       // Assert
-      assert.equal(eventData.element, element);
+      assert.equal(event.target, element);
       done();
     });
 

--- a/test/layers_test.js
+++ b/test/layers_test.js
@@ -96,10 +96,10 @@ describe('layers', function () {
 
   it('addLayers: should fire CornerstoneLayerAdded', function (done) {
     // Arrange
-    $(this.element).on('CornerstoneLayerAdded', (event, eventData) => {
+    this.element.addEventListener('cornerstonelayeradded', (event) => {
       // Assert
-      expect(eventData).to.be.an('object');
-      expect(eventData);
+      expect(event.detail).to.be.an('object');
+      expect(event.detail);
       done();
     });
 
@@ -221,9 +221,9 @@ describe('layers', function () {
 
     const layerId2 = addLayer(this.element, this.image2);
 
-    $(this.element).on('CornerstoneActiveLayerChanged', (event, eventData) => {
+    this.element.addEventListener('cornerstoneactivelayerchanged', (event) => {
       // Assert
-      expect(eventData.layerId).to.equal(layerId2);
+      expect(event.detail.layerId).to.equal(layerId2);
       done();
     });
 

--- a/test/updateImage_test.js
+++ b/test/updateImage_test.js
@@ -46,8 +46,8 @@ describe('Update a displayed image', function () {
     updateImage(element);
 
     // Assert
-    $(element).on('CornerstoneImageRendered', function (event, eventData) {
-      assert.equal(eventData.element, element);
+    element.addEventListener('cornerstoneimagerendered', function (event) {
+      assert.equal(event.target, element);
       done();
     });
   });


### PR DESCRIPTION
This PR removes jQuery event listeners from all tests, and fixes a minor issue with testing on phantomjs.