### PR TITLE
 Adding polyfill for CustomEvents and fixing lint warnings

### DIFF
--- a/src/internal/storedPixelDataToCanvasImageDataRGBA.js
+++ b/src/internal/storedPixelDataToCanvasImageDataRGBA.js
@@ -2,7 +2,7 @@ import now from './now.js';
 
 /**
  * This function transforms stored pixel values into a canvas image data buffer
- * by using a LUT. 
+ * by using a LUT.
  *
  * @param {Image} image A Cornerstone Image Object
  * @param {Array} lut Lookup table array

--- a/src/rendering/renderGrayscaleImage.js
+++ b/src/rendering/renderGrayscaleImage.js
@@ -107,7 +107,7 @@ export function renderGrayscaleImage (enabledElement, invalidated) {
  *
  * @param {EnabledElementLayer} layer The layer that the image will be added to
  * @param {Boolean} invalidated - true if pixel data has been invalidated and cached rendering should not be used
- * @param {Boolean} [useAlphaChannel] - Whether or not to render the grayscale image using only the alpha channel. 
+ * @param {Boolean} [useAlphaChannel] - Whether or not to render the grayscale image using only the alpha channel.
                                         This does not work if this layer is not the first layer in the enabledElement.
  * @returns {void}
  */
@@ -132,4 +132,3 @@ export function addGrayscaleLayer (layer, invalidated, useAlphaChannel = false) 
 
   layer.renderingTools = saveLastRendered(layer);
 }
-

--- a/src/triggerEvent.js
+++ b/src/triggerEvent.js
@@ -9,7 +9,15 @@ import { external } from './externalModules.js';
  * @returns {void}
  */
 export default function triggerEvent (el, type, detail = null) {
-  const event = new CustomEvent(type.toLocaleLowerCase(), { detail });
+  let event;
+
+  // This check is needed to polyfill CustomEvent on IE11-
+  if (window.CustomEvent) {
+    event = new CustomEvent(type.toLocaleLowerCase(), { detail });
+  } else {
+    event = document.createEvent('CustomEvent');
+    event.initCustomEvent(type.toLocaleLowerCase(), true, true, detail);
+  }
 
   // TODO: remove jQuery event triggers
   external.$(el).trigger(type, detail);

--- a/test/imageCache_test.js
+++ b/test/imageCache_test.js
@@ -6,8 +6,8 @@ import { default as imageCache,
   getImagePromise,
   removeImagePromise,
   getCacheInfo,
-  purgeCache,
-  changeImageIdCacheSize } from '../src/imageCache.js';
+  // changeImageIdCacheSize,
+  purgeCache } from '../src/imageCache.js';
 
 import events from '../src/events.js';
 
@@ -181,7 +181,7 @@ describe('Store, retrieve, and remove imagePromises from the cache', function ()
     assert.throws(() => removeImagePromise('RandomImageId'));
   });
 
-  /*it('should allow image promises to have their cache size changed', function () {
+  /* it('should allow image promises to have their cache size changed', function () {
     const image = this.image;
     const imagePromise = this.imagePromise;
     const newCacheSize = 500;
@@ -224,6 +224,7 @@ describe('Store, retrieve, and remove imagePromises from the cache', function ()
     setMaximumSizeBytes(1000);
 
     const promises = [];
+
     for (let i = 0; i < 10; i++) {
       // Create the image
       const imagePromise = $.Deferred();


### PR DESCRIPTION
This polyfill was [already in the code](https://github.com/chafey/cornerstone/commit/a6829bd134849e21935942063f5db49d1a706f9a#diff-d3851d6968f9cb93caba319845d6e094L8) in the past but it was removed by mistake.

I also removed some lint warnings which were being logged during the test.